### PR TITLE
Symfony 6 & 7 compatibility #9911

### DIFF
--- a/bin/anonymizer
+++ b/bin/anonymizer
@@ -26,7 +26,7 @@ $filename = getcwd() . '/.env';
 
 if (file_exists($filename)) {
     $dotenv = new Dotenv();
-    $dotenv->load($filename);
+    $dotenv->loadEnv($filename);
 }
 
 $application = new Application('Anonymizer', '0.0.1');

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,15 @@
         }
     ],
     "require": {
-
-        "symfony/yaml": "^4.0|^3.0|^2.7",
-	      "fzaninotto/faker": "~1.0",
+        "php": ">=8.2",
+        "ext-pdo": "*",
+	    "fakerphp/faker": "~1.0",
         "linkorb/boost": "~1.0",
         "linkorb/connector": "~1.0",
-        "linkorb/collection": "~1.0"
-    },
-    "require-dev": {
-        "symfony/dotenv": "~3.0",
-        "symfony/console": "~2.4"
+        "linkorb/collection": "~1.0",
+        "symfony/console": "^6.4.0 || ^7.2.0",
+        "symfony/dotenv": "*",
+        "symfony/yaml": "*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
 	    "fakerphp/faker": "~1.0",
         "linkorb/boost": "~1.0",
         "linkorb/connector": "~1.0",
-        "linkorb/collection": "~1.0",
         "symfony/console": "^6.4.0 || ^7.2.0",
         "symfony/dotenv": "*",
         "symfony/yaml": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,36 +4,45 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb39093de7cd256658b34250a64ef2b3",
+    "content-hash": "7adc340cae8d3d9a7b01c17d31766789",
     "packages": [
         {
-            "name": "fzaninotto/faker",
-            "version": "v1.9.2",
+            "name": "fakerphp/faker",
+            "version": "v1.24.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "848d8125239d7dbf8ab25cb7f054f1a630e68c2e"
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/848d8125239d7dbf8ab25cb7f054f1a630e68c2e",
-                "reference": "848d8125239d7dbf8ab25cb7f054f1a630e68c2e",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.4 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
             },
             "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
                 "ext-intl": "*",
-                "phpunit/phpunit": "^4.8.35 || ^5.7",
-                "squizlabs/php_codesniffer": "^2.9.2"
+                "phpunit/phpunit": "^9.5.26",
+                "symfony/phpunit-bridge": "^5.4.16"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.9-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Faker\\": "src/Faker/"
@@ -55,11 +64,10 @@
                 "fixtures"
             ],
             "support": {
-                "issues": "https://github.com/fzaninotto/Faker/issues",
-                "source": "https://github.com/fzaninotto/Faker/tree/v1.9.2"
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
             },
-            "abandoned": true,
-            "time": "2020-12-11T09:56:16+00:00"
+            "time": "2024-11-21T13:46:39+00:00"
         },
         {
             "name": "linkorb/boost",
@@ -158,16 +166,16 @@
         },
         {
             "name": "linkorb/connector",
-            "version": "v1.4.0",
+            "version": "v1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/linkorb/connector.git",
-                "reference": "d10984fcb5d8b24929e71d844bb385da5b87991e"
+                "reference": "bfa08a8b76ec3e5659b62ff7ee588da3611119f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/linkorb/connector/zipball/d10984fcb5d8b24929e71d844bb385da5b87991e",
-                "reference": "d10984fcb5d8b24929e71d844bb385da5b87991e",
+                "url": "https://api.github.com/repos/linkorb/connector/zipball/bfa08a8b76ec3e5659b62ff7ee588da3611119f1",
+                "reference": "bfa08a8b76ec3e5659b62ff7ee588da3611119f1",
                 "shasum": ""
             },
             "require": {
@@ -200,96 +208,36 @@
             ],
             "support": {
                 "issues": "https://github.com/linkorb/connector/issues",
-                "source": "https://github.com/linkorb/connector/tree/v1.4.0"
+                "source": "https://github.com/linkorb/connector/tree/v1.5.1"
             },
-            "time": "2021-05-12T13:49:47+00:00"
+            "time": "2024-05-24T13:46:47+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.3.18",
+            "name": "psr/container",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "af615970e265543a26ee712c958404eb9b7ac93d"
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/af615970e265543a26ee712c958404eb9b7ac93d",
-                "reference": "af615970e265543a26ee712c958404eb9b7ac93d",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "require-dev": {
-                "symfony/console": "~2.8|~3.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/3.3"
-            },
-            "time": "2018-01-20T15:04:53+00:00"
-        }
-    ],
-    "packages-dev": [
-        {
-            "name": "psr/log",
-            "version": "1.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Container\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -302,53 +250,65 @@
                     "homepage": "https://www.php-fig.org/"
                 }
             ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
             "keywords": [
-                "log",
-                "psr",
-                "psr-3"
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.52",
+            "version": "v7.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "cbcf4b5e233af15cd2bbd50dee1ccc9b7927dc12"
+                "reference": "0e2e3f38c192e93e622e41ec37f4ca70cfedf218"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/cbcf4b5e233af15cd2bbd50dee1ccc9b7927dc12",
-                "reference": "cbcf4b5e233af15cd2bbd50dee1ccc9b7927dc12",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0e2e3f38c192e93e622e41ec37f4ca70cfedf218",
+                "reference": "0e2e3f38c192e93e622e41ec37f4ca70cfedf218",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9",
-                "symfony/debug": "^2.7.2|~3.0.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.2",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^6.4|^7.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.1|~3.0.0",
-                "symfony/process": "~2.1|~3.0.0"
-            },
-            "suggest": {
-                "psr/log-implementation": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/process": ""
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.8-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Console\\": ""
@@ -371,50 +331,63 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Console Component",
+            "description": "Eases the creation of beautiful and testable command line interfaces",
             "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v2.8.52"
+                "source": "https://github.com/symfony/console/tree/v7.2.6"
             },
-            "time": "2018-11-20T15:55:20+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-04-07T19:09:28+00:00"
         },
         {
-            "name": "symfony/debug",
-            "version": "v3.0.9",
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.5.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "697c527acd9ea1b2d3efac34d9806bf255278b0a"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/697c527acd9ea1b2d3efac34d9806bf255278b0a",
-                "reference": "697c527acd9ea1b2d3efac34d9806bf255278b0a",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
-                "psr/log": "~1.0"
-            },
-            "conflict": {
-                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
-            },
-            "require-dev": {
-                "symfony/class-loader": "~2.8|~3.0",
-                "symfony/http-kernel": "~2.8|~3.0"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "3.5-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Debug\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "files": [
+                    "function.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -423,41 +396,59 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
                 {
                     "name": "Symfony Community",
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Debug Component",
+            "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/debug/tree/3.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
             },
-            "abandoned": "symfony/error-handler",
-            "time": "2016-07-30T07:22:48+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
         },
         {
             "name": "symfony/dotenv",
-            "version": "v3.4.47",
+            "version": "v7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dotenv.git",
-                "reference": "1022723ac4f56b001d99691d96c6025dbf1404f1"
+                "reference": "28347a897771d0c28e99b75166dd2689099f3045"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dotenv/zipball/1022723ac4f56b001d99691d96c6025dbf1404f1",
-                "reference": "1022723ac4f56b001d99691d96c6025dbf1404f1",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/28347a897771d0c28e99b75166dd2689099f3045",
+                "reference": "28347a897771d0c28e99b75166dd2689099f3045",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=8.2"
+            },
+            "conflict": {
+                "symfony/console": "<6.4",
+                "symfony/process": "<6.4"
             },
             "require-dev": {
-                "symfony/process": "^3.4.2|^4.0"
+                "symfony/console": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -490,7 +481,7 @@
                 "environment"
             ],
             "support": {
-                "source": "https://github.com/symfony/dotenv/tree/v3.4.47"
+                "source": "https://github.com/symfony/dotenv/tree/v7.2.0"
             },
             "funding": [
                 {
@@ -506,24 +497,263 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2024-11-27T11:18:42+00:00"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.27.0",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.32.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.32.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.32.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.32.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.32.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-mbstring": "*"
@@ -533,12 +763,9 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -573,7 +800,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -589,15 +816,261 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2024-12-23T08:48:59+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:20:29+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v7.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "a214fe7d62bd4df2a76447c67c6b26e1d5e74931"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/a214fe7d62bd4df2a76447c67c6b26e1d5e74931",
+                "reference": "a214fe7d62bd4df2a76447c67c6b26e1d5e74931",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.1",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v7.2.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-04-20T20:18:16+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.2.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "0feafffb843860624ddfd13478f481f4c3cd8b23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/0feafffb843860624ddfd13478f481f4c3cd8b23",
+                "reference": "0feafffb843860624ddfd13478f481f4c3cd8b23",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.2.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-04-04T10:10:11+00:00"
         }
     ],
+    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform": {
+        "php": ">=8.2",
+        "ext-pdo": "*"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7adc340cae8d3d9a7b01c17d31766789",
+    "content-hash": "1978bd319da46884b1b43bd72c3a4fc3",
     "packages": [
         {
             "name": "fakerphp/faker",
@@ -117,52 +117,6 @@
                 "source": "https://github.com/linkorb/boost/tree/master"
             },
             "time": "2018-02-23T09:33:35+00:00"
-        },
-        {
-            "name": "linkorb/collection",
-            "version": "v1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/linkorb/collection.git",
-                "reference": "ff2038ebd17ecb8bfd1becd7bc649f668d847b40"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/linkorb/collection/zipball/ff2038ebd17ecb8bfd1becd7bc649f668d847b40",
-                "reference": "ff2038ebd17ecb8bfd1becd7bc649f668d847b40",
-                "shasum": ""
-            },
-            "type": "application",
-            "autoload": {
-                "psr-4": {
-                    "Collection\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "LinkORB",
-                    "email": "engineering@linkorb.com",
-                    "role": "Development"
-                }
-            ],
-            "description": "Super powered collections",
-            "homepage": "https://github.com/linkorb/collection",
-            "keywords": [
-                "array",
-                "collection",
-                "data structure",
-                "linkorb",
-                "php-ds"
-            ],
-            "support": {
-                "issues": "https://github.com/linkorb/collection/issues",
-                "source": "https://github.com/linkorb/collection/tree/v1.0.0"
-            },
-            "time": "2017-08-05T08:56:43+00:00"
         },
         {
             "name": "linkorb/connector",

--- a/src/Anonymizer.php
+++ b/src/Anonymizer.php
@@ -13,7 +13,7 @@ use RuntimeException;
 
 class Anonymizer
 {
-    protected array $columns = [];
+    protected \ArrayObject $columns;
     protected array $truncate = [];
     protected array $drop = [];
     protected array $flags = [];
@@ -21,6 +21,10 @@ class Anonymizer
 
     use BoostTrait;
     use ProtectedAccessorsTrait;
+
+    public function __construct() {
+        $this->columns = new \ArrayObject();
+    }
 
     private function loadSchema(PDO $pdo, OutputInterface $output): void
     {

--- a/src/Anonymizer.php
+++ b/src/Anonymizer.php
@@ -2,6 +2,8 @@
 
 namespace Anonymizer;
 
+use Anonymizer\Method\FakerMethod;
+use Anonymizer\Method\FixedMethod;
 use Boost\BoostTrait;
 use Boost\Accessors\ProtectedAccessorsTrait;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -13,11 +15,11 @@ use RuntimeException;
 
 class Anonymizer
 {
-    protected $name;
-    protected $columns = [];
-    protected $truncate = [];
-    protected $drop = [];
-    protected $flags = [];
+    protected TypedArray $columns;
+    protected array $truncate = [];
+    protected array $drop = [];
+    protected array $flags = [];
+    protected array $schema = [];
 
     use BoostTrait;
     use ProtectedAccessorsTrait;
@@ -27,7 +29,7 @@ class Anonymizer
         $this->columns = new TypedArray(Column::class);
     }
 
-    private function loadSchema(PDO $pdo, OutputInterface $output)
+    private function loadSchema(PDO $pdo, OutputInterface $output): void
     {
         $stmt = $pdo->prepare("SHOW tables;");
         $stmt->execute();
@@ -60,7 +62,7 @@ class Anonymizer
         //print_r($this->schema); exit("DONE");
     }
 
-    public function expandTables($pattern)
+    public function expandTables($pattern): array
     {
         $tableNames = [];
         foreach ($this->schema as $tableName => $columns) {
@@ -71,7 +73,7 @@ class Anonymizer
         return $tableNames;
     }
 
-    public function expandColumns($tableName, $pattern)
+    public function expandColumns($tableName, $pattern): array
     {
         $columnNames = [];
         foreach ($this->schema[$tableName] as $columnName => $data) {
@@ -82,7 +84,7 @@ class Anonymizer
         return $columnNames;
     }
 
-    public function execute(PDO $pdo, OutputInterface $output)
+    public function execute(PDO $pdo, OutputInterface $output): void
     {
         $this->loadSchema($pdo, $output);
 
@@ -90,10 +92,10 @@ class Anonymizer
             $output->writeLn("Anonymizing column: <info>" . $column->identifier() . "</info> ({$column->displayMethod()})");
             switch ($column->getMethod()) {
                 case 'faker':
-                    $method = new \Anonymizer\Method\FakerMethod($column->getArguments());
+                    $method = new FakerMethod($column->getArguments());
                     break;
                 case 'fixed':
-                    $method = new \Anonymizer\Method\FixedMethod($column->getArguments());
+                    $method = new FixedMethod($column->getArguments());
                     break;
                 default:
                     throw new RuntimeException("Unsupported method: " . $column->getMethod());
@@ -188,7 +190,7 @@ class Anonymizer
                         $progress->advance();
                     }
                     // Fix missing values
-                    foreach ($missing[$cascade] as $k => $missingValue) {
+                    foreach ($missing[$cascade] as $missingValue) {
                         $sql = "UPDATE " . $cascadeTable . ' SET ' . $cascadeColumn . '=null WHERE ' . $cascadeColumn . '=:missingValue';
                         $subStmt = $pdo->prepare(
                             $sql
@@ -299,7 +301,7 @@ class Anonymizer
 
     }
 
-    public function setFlag($key, $value)
+    public function setFlag($key, $value): void
     {
         $this->flags[$key] = $value;
     }

--- a/src/Anonymizer.php
+++ b/src/Anonymizer.php
@@ -8,14 +8,12 @@ use Boost\BoostTrait;
 use Boost\Accessors\ProtectedAccessorsTrait;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Collection\TypedArray;
-use Anonymizer\Model\Column;
 use PDO;
 use RuntimeException;
 
 class Anonymizer
 {
-    protected TypedArray $columns;
+    protected array $columns = [];
     protected array $truncate = [];
     protected array $drop = [];
     protected array $flags = [];
@@ -23,11 +21,6 @@ class Anonymizer
 
     use BoostTrait;
     use ProtectedAccessorsTrait;
-
-    public function __construct()
-    {
-        $this->columns = new TypedArray(Column::class);
-    }
 
     private function loadSchema(PDO $pdo, OutputInterface $output): void
     {

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -34,12 +34,12 @@ class RunCommand extends Command
 
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        $filename = getenv('ANONYMIZER_FILENAME');
-        $dsn = getenv('ANONYMIZER_DSN');
-        $configPath = getenv('ANONYMIZER_CONFIG_PATH');
+        $filename = $_ENV['ANONYMIZER_FILENAME'];
+        $dsn = $_ENV['ANONYMIZER_DSN'];
+        $configPath = $_ENV['ANONYMIZER_CONFIG_PATH'];
 
         if (!$dsn) {
-            $dsn = getenv('PDO');
+            $dsn = $_ENV['PDO'];
         }
 
         if ($input->getArgument('config')) {

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -21,8 +21,7 @@ class RunCommand extends Command
             ->addArgument(
                 'config',
                 InputArgument::OPTIONAL,
-                'Configuration filename',
-                'anonymizer.yml'
+                'Configuration filename'
             )
             ->addArgument(
                 'dsn',
@@ -43,8 +42,17 @@ class RunCommand extends Command
         }
 
         if ($input->getArgument('config')) {
+            if (!empty($filename)) {
+                $output->writeln("<warning>Both ANONYMIZER_FILENAME env, and config argument are present. Config argument takes precedence.</warning>");
+            }
             $filename = $input->getArgument('config');
+        } else {
+            if (empty($filename)) {
+                $filename = 'anonymizer.yml';
+                $output->writeln("<warning>No configuration specified, assuming default configuration file</warning>");
+            }
         }
+
         if ($input->getArgument('dsn')) {
             $dsn = $input->getArgument('dsn');
         }

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -6,7 +6,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Anonymizer\Loader\YamlLoader;
 use RuntimeException;
 use Connector\Connector;
@@ -14,7 +13,7 @@ use Connector\Backend\IniBackend;
 
 class RunCommand extends Command
 {
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('run')
@@ -33,7 +32,7 @@ class RunCommand extends Command
         ;
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $filename = getenv('ANONYMIZER_FILENAME');
         $dsn = getenv('ANONYMIZER_DSN');
@@ -77,6 +76,6 @@ class RunCommand extends Command
         $anonymizer = $loader->loadFile($filename);
         $anonymizer->execute($pdo, $output);
         $output->writeLn("Done");
-
+        return Command::SUCCESS;
     }
 }

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -34,11 +34,11 @@ class RunCommand extends Command
 
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        $filename = $_ENV['ANONYMIZER_FILENAME'];
-        $dsn = $_ENV['ANONYMIZER_DSN'];
-        $configPath = $_ENV['ANONYMIZER_CONFIG_PATH'];
+        $filename = $_ENV['ANONYMIZER_FILENAME'] ?? "";
+        $dsn = $_ENV['ANONYMIZER_DSN'] ?? "";
+        $configPath = $_ENV['ANONYMIZER_CONFIG_PATH'] ?? "";
 
-        if (!$dsn) {
+        if (empty($dsn)) {
             $dsn = $_ENV['PDO'];
         }
 
@@ -49,10 +49,10 @@ class RunCommand extends Command
             $dsn = $input->getArgument('dsn');
         }
 
-        if (!$filename) {
+        if (empty($filename)) {
             throw new RuntimeException("Config file not specified (use argument or environment variable)");
         }
-        if (!$dsn) {
+        if (empty($dsn)) {
             throw new RuntimeException("DSN not specified (use argument or environment variable)");
         }
 
@@ -61,7 +61,7 @@ class RunCommand extends Command
         $output->writeLn(" * Config: " . $filename);
 
         $connector = new Connector();
-        if ($configPath) {
+        if (false === empty($configPath)) {
             $backend = new IniBackend($configPath, '.conf');
             $connector->registerBackend($backend);
         }

--- a/src/Loader/ArrayLoader.php
+++ b/src/Loader/ArrayLoader.php
@@ -31,7 +31,7 @@ class ArrayLoader
                 if (isset($columnData['cascades'])) {
                     $column->setCascades($columnData['cascades']);
                 }
-                $anonymizer->getColumns()[] = $column;
+                $anonymizer->getColumns()->append($column);
             }
         }
         if (isset($data['truncate'])) {

--- a/src/Loader/ArrayLoader.php
+++ b/src/Loader/ArrayLoader.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 class ArrayLoader
 {
-    public function loadData($data)
+    public function loadData($data): Anonymizer
     {
         $anonymizer = new Anonymizer();
 

--- a/src/Loader/ArrayLoader.php
+++ b/src/Loader/ArrayLoader.php
@@ -31,7 +31,7 @@ class ArrayLoader
                 if (isset($columnData['cascades'])) {
                     $column->setCascades($columnData['cascades']);
                 }
-                $anonymizer->getColumns()->add($column);
+                $anonymizer->getColumns()[] = $column;
             }
         }
         if (isset($data['truncate'])) {

--- a/src/Loader/YamlLoader.php
+++ b/src/Loader/YamlLoader.php
@@ -2,12 +2,13 @@
 
 namespace Anonymizer\Loader;
 
+use Anonymizer\Anonymizer;
 use Symfony\Component\Yaml\Yaml;
 
 
 class YamlLoader extends ArrayLoader
 {
-    public function loadFile($filename)
+    public function loadFile($filename): Anonymizer
     {
         $yaml = file_get_contents($filename);
         $data = Yaml::parse($yaml);

--- a/src/Method/FakerMethod.php
+++ b/src/Method/FakerMethod.php
@@ -26,7 +26,7 @@ class FakerMethod
         return $value;
     }
 
-    public function getScope()
+    public function getScope(): string
     {
         return 'row';
     }

--- a/src/Method/FixedMethod.php
+++ b/src/Method/FixedMethod.php
@@ -5,6 +5,11 @@ namespace Anonymizer\Method;
 class FixedMethod
 {
     protected $faker;
+    /**
+     * @var mixed
+     */
+    private $value;
+
     public function __construct($arguments = [])
     {
         $this->value = $arguments['value'];
@@ -15,7 +20,7 @@ class FixedMethod
         return $this->value;
     }
 
-    public function getScope()
+    public function getScope(): string
     {
         return 'table';
     }

--- a/src/Model/Column.php
+++ b/src/Model/Column.php
@@ -4,9 +4,8 @@ namespace Anonymizer\Model;
 
 use Boost\BoostTrait;
 use Boost\Accessors\ProtectedAccessorsTrait;
-use Collection\Identifiable;
 
-class Column implements Identifiable
+class Column
 {
     protected $name;
     protected $tableName;

--- a/src/Model/Column.php
+++ b/src/Model/Column.php
@@ -28,7 +28,7 @@ class Column implements Identifiable
         return $this->method;
     }
 
-    public function identifier()
+    public function identifier(): string
     {
        return $this->tableName . '.' . $this->name;
     }


### PR DESCRIPTION
Package made compatible with projects that run symfony 6/7. Switches out to a community maintained fork of Faker. Drops the linkorb/collection package in favor of using ArrayObject instead of TypedArray. Miscelaneous cleanups and typehints added.

<!-- Please indicate if your PR introduces a breaking change -->
- [x] Breaking change: fix or feature that would cause existing functionality to not work as expected

A bump to a v1 would be in order after merging this PR. Minimal PHP version has been bumped to PHP 8.2

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [Contributing](https://github.com/linkorb/.github/blob/master/CONTRIBUTING.md) doc
- [x] I have read the [Creating and reviewing pull requests at LinkORB guide](https://engineering.linkorb.com/topics/git/articles/reviewing-pr/) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added/updated necessary documentation in the README.md or doc/ directories (if appropriate)
